### PR TITLE
DEBUG: Arrêt envoi mail rappel

### DIFF
--- a/django/telefab/main/models.py
+++ b/django/telefab/main/models.py
@@ -207,7 +207,7 @@ class Loan(models.Model):
 			title = u"Téléfab : matériel prêté à rendre"
 		else:
 			title = u"Téléfab : emprunt de matériel"
-		send_mail(title, message, EMAIL_FROM, [self.borrower.email])
+		#send_mail(title, message, EMAIL_FROM, [self.borrower.email])
 
 
 class EquipmentLoan(models.Model):


### PR DESCRIPTION
Pb d'envois de mails de rappel alors que les prêts ont été rendus. 
Solution temporaire: arrêt de l'envoi des mails de rappels.